### PR TITLE
Modifying naming conventions to optimize multiple microservices

### DIFF
--- a/Acl/src/EnvironmentOptionsExts/EnvironmentOptionsExt.cs
+++ b/Acl/src/EnvironmentOptionsExts/EnvironmentOptionsExt.cs
@@ -2,6 +2,9 @@
 
 public static class EnvironmentOptionsExt
 {
-    public static string GetResourceName(this EnvironmentOptions settings, string resourceType) => $"{settings.Environment}-{settings.RegionShortName}-{resourceType}-{settings.ServiceName}".ToLowerInvariant();
-    public static string GetResourceNameShared(this EnvironmentOptions settings, string resourceType) => $"{settings.Environment}-{resourceType}-{settings.ServiceName}".ToLowerInvariant();
+    public static string GetResourceName(this EnvironmentOptions settings, string resourceType) =>
+        $"{settings.Environment}-{settings.RegionShortName}-{settings.ServiceName}-{resourceType}".ToLowerInvariant();
+
+    public static string GetResourceNameShared(this EnvironmentOptions settings, string resourceType) =>
+        $"{settings.Environment}-{settings.ServiceName}-{resourceType}".ToLowerInvariant();
 }

--- a/Acl/src/EnvironmentOptionsExts/EnvironmentOptionsExt.cs
+++ b/Acl/src/EnvironmentOptionsExts/EnvironmentOptionsExt.cs
@@ -2,9 +2,13 @@
 
 public static class EnvironmentOptionsExt
 {
+    // Region specific resources.
+    // Example: App Service, Key Vault, Managed Identity. etc.
     public static string GetResourceName(this EnvironmentOptions settings, string resourceType) =>
         $"{settings.Environment}-{settings.RegionShortName}-{settings.ServiceName}-{resourceType}".ToLowerInvariant();
 
+    // Shared resources.
+    // Example: Storage Account, Cosmos DB, SQL etc.
     public static string GetResourceNameShared(this EnvironmentOptions settings, string resourceType) =>
         $"{settings.Environment}-{settings.ServiceName}-{resourceType}".ToLowerInvariant();
 }

--- a/Acl/tests/CosmosDbTests.cs
+++ b/Acl/tests/CosmosDbTests.cs
@@ -16,7 +16,7 @@ public class CosmosDbTests
             ServiceName = "bwf"
         };
 
-        var expected = $"{env}-cosno-bwf";
+        var expected = $"{env}-bwf-cosno";
 
         // Act
         var actual = environmentOptions.GetCosmosDbNameShared();
@@ -26,10 +26,10 @@ public class CosmosDbTests
     }
 
     [Theory]
-    [InlineData(CloudType.AzureCloud, "https://ppe-cosno-bwf.documents.azure.com:443/")]
-    [InlineData(CloudType.AzureUSGovernment, "https://ppe-cosno-bwf.documents.azure.us:443/")]
-    [InlineData(CloudType.AzureChinaCloud, "https://ppe-cosno-bwf.documents.azure.cn:443/")]
-    [InlineData(CloudType.AzureGermanCloud, "https://ppe-cosno-bwf.documents.azure.com:443/")]
+    [InlineData(CloudType.AzureCloud, "https://ppe-bwf-cosno.documents.azure.com:443/")]
+    [InlineData(CloudType.AzureUSGovernment, "https://ppe-bwf-cosno.documents.azure.us:443/")]
+    [InlineData(CloudType.AzureChinaCloud, "https://ppe-bwf-cosno.documents.azure.cn:443/")]
+    [InlineData(CloudType.AzureGermanCloud, "https://ppe-bwf-cosno.documents.azure.com:443/")]
     public void Will_get_url_for_Cloud(string cloudType, string expectedUrl)
     {
         // Arrange
@@ -46,6 +46,5 @@ public class CosmosDbTests
 
         // Assert
         actualUrl.Should().Be(expectedUrl);
-
     }
 }

--- a/Acl/tests/KeyVaultTests.cs
+++ b/Acl/tests/KeyVaultTests.cs
@@ -16,7 +16,7 @@ public class KeyVaultTests
             ServiceName = "bwf"
         };
 
-        var expected = $"{env}-usw2-kv-bwf";
+        var expected = $"{env}-usw2-bwf-kv";
 
         // Act
         var actual = environmentOptions.GetKeyVaultName();
@@ -26,10 +26,10 @@ public class KeyVaultTests
     }
 
     [Theory]
-    [InlineData(CloudType.AzureCloud, "https://ppe-usw2-kv-bwf.vault.azure.net/")]
-    [InlineData(CloudType.AzureUSGovernment, "https://ppe-usw2-kv-bwf.vault.usgovcloudapi.net/")]
-    [InlineData(CloudType.AzureChinaCloud, "https://ppe-usw2-kv-bwf.vault.azure.cn/")]
-    [InlineData(CloudType.AzureGermanCloud, "https://ppe-usw2-kv-bwf.vault.microsoftazure.de/")]
+    [InlineData(CloudType.AzureCloud, "https://ppe-usw2-bwf-kv.vault.azure.net/")]
+    [InlineData(CloudType.AzureUSGovernment, "https://ppe-usw2-bwf-kv.vault.usgovcloudapi.net/")]
+    [InlineData(CloudType.AzureChinaCloud, "https://ppe-usw2-bwf-kv.vault.azure.cn/")]
+    [InlineData(CloudType.AzureGermanCloud, "https://ppe-usw2-bwf-kv.vault.microsoftazure.de/")]
     public void Will_get_keyvault_uri_for_Cloud(string cloudType, string expectedUri)
     {
         // Arrange

--- a/Acl/tests/ServiceBusTests.cs
+++ b/Acl/tests/ServiceBusTests.cs
@@ -17,7 +17,7 @@ public class ServiceBusTests
             ServiceName = "bwf"
         };
 
-        var expected = $"{env}-sbns-bwf";
+        var expected = $"{env}-bwf-sbns";
 
         // Act
         var actual = environmentOptions.GetServiceBusName();
@@ -27,10 +27,10 @@ public class ServiceBusTests
     }
 
     [Theory]
-    [InlineData(CloudType.AzureCloud, "ppe-sbns-bwf.servicebus.windows.net")]
-    [InlineData(CloudType.AzureUSGovernment, "ppe-sbns-bwf.servicebus.usgovcloudapi.net")]
-    [InlineData(CloudType.AzureChinaCloud, "ppe-sbns-bwf.servicebus.chinacloudapi.cn")]
-    [InlineData(CloudType.AzureGermanCloud, "ppe-sbns-bwf.servicebus.cloudapi.de")]
+    [InlineData(CloudType.AzureCloud, "ppe-bwf-sbns.servicebus.windows.net")]
+    [InlineData(CloudType.AzureUSGovernment, "ppe-bwf-sbns.servicebus.usgovcloudapi.net")]
+    [InlineData(CloudType.AzureChinaCloud, "ppe-bwf-sbns.servicebus.chinacloudapi.cn")]
+    [InlineData(CloudType.AzureGermanCloud, "ppe-bwf-sbns.servicebus.cloudapi.de")]
     public void Will_get_namespace_for_Cloud(string cloudType, string expectedNamespace)
     {
         // Arrange

--- a/Acl/tests/StorageNameTests.cs
+++ b/Acl/tests/StorageNameTests.cs
@@ -18,7 +18,7 @@ public class StorageNameTests
             ServiceName = "bwf"
         };
 
-        var expected = $"{env}stbwf";
+        var expected = $"{env}bwfst";
 
         // Act
         var actual = environmentOptions.GetStorageNameShared();
@@ -46,10 +46,10 @@ public class StorageNameTests
     }
 
     [Theory]
-    [InlineData(CloudType.AzureCloud, "https://ppestbwf.blob.core.windows.net")]
-    [InlineData(CloudType.AzureUSGovernment, "https://ppestbwf.blob.core.usgovcloudapi.net")]
-    [InlineData(CloudType.AzureChinaCloud, "https://ppestbwf.blob.core.chinacloud.cn")]
-    [InlineData(CloudType.AzureGermanCloud, "https://ppestbwf.blob.core.cloudapi.de")]
+    [InlineData(CloudType.AzureCloud, "https://ppebwfst.blob.core.windows.net")]
+    [InlineData(CloudType.AzureUSGovernment, "https://ppebwfst.blob.core.usgovcloudapi.net")]
+    [InlineData(CloudType.AzureChinaCloud, "https://ppebwfst.blob.core.chinacloud.cn")]
+    [InlineData(CloudType.AzureGermanCloud, "https://ppebwfst.blob.core.cloudapi.de")]
     public void Will_get_blob_url_for_Cloud(string cloudType, string expectedUrl)
     {
         // Arrange


### PR DESCRIPTION
Modifying naming conventions to optimize resource organization for teams hosting multiple microservices in one Azure subscription.

```charp
    // Region specific resources.
    // Example: App Service, Key Vault, Managed Identity. etc.
    public static string GetResourceName(this EnvironmentOptions settings, string resourceType) =>
        $"{settings.Environment}-{settings.RegionShortName}-{settings.ServiceName}-{resourceType}".ToLowerInvariant();

    // Shared resources.
    // Example: Storage Account, Cosmos DB, SQL etc.
    public static string GetResourceNameShared(this EnvironmentOptions settings, string resourceType) =>
        $"{settings.Environment}-{settings.ServiceName}-{resourceType}".ToLowerInvariant();
```