### PR TITLE
﻿Update Trellis to 3.0.0-alpha.140 and adopt new framework APIs

### DIFF
--- a/template/.github/copilot-instructions.md
+++ b/template/.github/copilot-instructions.md
@@ -271,7 +271,7 @@ public Result<OrderStatus> Submit() => _machine.FireResult("Submit");
 
 ### EF Core
 
-- 🔴 **Always call `ApplyTrellisConventions`** in `ConfigureConventions` — it handles all scalar Trellis value objects automatically. 🔴 Do NOT write `HasConversion()` for types handled by Trellis conventions — it silently overrides the convention and causes runtime failures. 🟢 If a custom type is not handled by `ApplyTrellisConventions`, use explicit EF mapping (`HasConversion`, `OwnsOne`, etc.) for that type only.
+- 🔴 **Always call `ApplyTrellisConventions`** in `ConfigureConventions` — it handles all scalar Trellis value objects automatically, including `RequiredString<T>`, `RequiredGuid<T>`, `RequiredInt<T>`, `RequiredDecimal<T>`, `RequiredDateTime<T>`, `RequiredBool<T>`, `RequiredLong<T>`, `RequiredEnum<T>`, and all built-in primitives (`EmailAddress`, `PhoneNumber`, etc.). 🔴 Do NOT write `HasConversion()` for types handled by Trellis conventions — it silently overrides the convention and causes runtime failures. 🟢 If a custom type is not handled by `ApplyTrellisConventions`, use explicit EF mapping (`HasConversion`, `OwnsOne`, etc.) for that type only.
 - 🟡 **`Money` properties** are auto-mapped by `ApplyTrellisConventions` — no `OwnsOne` needed. See §12 in `trellis-api-reference.md` for column naming.
 - 🟢 **Custom composite `ValueObject` types** (e.g., `ShippingAddress` with multiple fields) are NOT auto-mapped. Map them using standard EF Core owned entities (`OwnsOne`, `OwnsMany`) — refer to [EF Core Owned Entity Types documentation](https://learn.microsoft.com/en-us/ef/core/modeling/owned-entities).
 - 🟡 **Owned collection property types** — use `IReadOnlyList<T>` (not `ReadOnlyCollection<T>`) for `OwnsMany` navigation properties. EF Core cannot populate `ReadOnlyCollection<T>` from a backing `List<T>` field during materialization.
@@ -334,6 +334,13 @@ result.ToCreatedAtActionResult(this, nameof(CustomersController.GetCustomer), o 
 
 🔴 **Use value object types — not primitives — in controller action parameters.** Trellis automatically converts route parameters, query parameters, and JSON body properties via model binding and JSON converters. Never call `.Create()` or `.TryCreate()` manually in controllers.
 
+🟡 **Service Level Indicator (SLI) attributes** — from the `ServiceLevelIndicators` package. Applied to controller action parameters:
+- `[CustomerResourceId]` — identifies the customer, customer group, or calling service
+- `[LocationId]` — the location where the service is running (e.g., Public cloud, West US 3 region, Azure Core)
+- `[Operation]` — the name of the operation
+
+See the [ServiceLevelIndicators documentation](https://github.com/xavierjohn/ServiceLevelIndicators) for details.
+
 **Registration** — add scalar value validation to the MVC pipeline in `Api/src/DependencyInjection.cs`:
 ```csharp
 services.AddControllers().AddScalarValueValidation();
@@ -343,7 +350,17 @@ And activate the middleware in `Program.cs`:
 app.UseScalarValueValidation();
 ```
 
-🟡 **Request/Response DTOs** live in `Api/src/{version}/Models/` (e.g., `Api/src/2026-03-26/Models/`). 🔴 Never expose domain types directly. Request DTOs can use scalar value object types as properties — they will be validated automatically via the JSON converter. Response DTOs should have a `static From(DomainType)` method for mapping from domain aggregates.
+🟡 **Request/Response DTOs** live in `Api/src/{version}/Models/` (e.g., `Api/src/2026-03-26/Models/`). 🔴 Never expose domain types directly. Request DTOs can use scalar value object types and `Money` as properties — they will be validated automatically via JSON converters. Response DTOs should have a `static From(DomainType)` method for mapping from domain aggregates.
+```csharp
+// ✅ All Trellis value objects work directly in request DTOs
+public record CreateProductRequest
+{
+    public ProductName Name { get; init; } = null!;    // scalar VO — validated by ParsableJsonConverter
+    public Sku Sku { get; init; } = null!;             // scalar VO
+    public Money UnitPrice { get; init; } = null!;     // structured VO — validated by MoneyJsonConverter
+}
+// JSON: { "name": "Widget", "sku": "WGT-001", "unitPrice": { "amount": 9.99, "currency": "USD" } }
+```
 
 ### API Versioning
 
@@ -403,6 +420,14 @@ The Scalar UI is available at `/scalar/{version}` (e.g., `/scalar/2026-11-12`).
 **API integration tests:** Use `WebApplicationFactory<Program>` with SQLite in-memory. Test HTTP round-trips, status codes, Problem Details, authorization enforcement. Use `MartinCostello.Logging.XUnit.v3` for test logging.
 
 **Do NOT** create `GlobalUsings.cs` files in test projects. Global usings come from `build/test.props`.
+
+🟡 **TRLS001 (`Result not handled`) in test setup code** — when calling methods like `todo.Start()` or `repo.SaveAsync()` in test setup where the result is intentionally ignored, suppress with `#pragma warning disable TRLS001` at the top of the file, or discard with `_ =`:
+```csharp
+#pragma warning disable TRLS001 // Result intentionally ignored in test setup
+
+// Or per-line:
+_ = todo.Start();
+```
 
 🔴 **`Maybe<T>` assertions** — use `.Should().HaveValue()` and `.Should().BeNone()` (from `Trellis.Testing`) to assert on `Maybe<T>` values. Do NOT use `.HasValue.Should().BeTrue()` or `.HasNoValue.Should().BeTrue()` — these bypass Trellis.Testing's assertion messages. Also available: `.Should().HaveValueEqualTo(expected)` and `.Should().HaveValueMatching(predicate)`.
 ```csharp

--- a/template/.github/trellis-api-reference.md
+++ b/template/.github/trellis-api-reference.md
@@ -147,8 +147,16 @@ bool HasValue { get; }
 bool HasNoValue { get; }
 T GetValueOrThrow(string? errorMessage = null)
 T GetValueOrDefault(T defaultValue)
+T GetValueOrDefault(Func<T> defaultFactory)
 bool TryGetValue(out T value)
 Maybe<TResult> Map<TResult>(Func<T, TResult> selector) where TResult : notnull
+Maybe<TResult> Bind<TResult>(Func<T, Maybe<TResult>> selector) where TResult : notnull
+Maybe<T> Or(T fallback)
+Maybe<T> Or(Func<T> fallbackFactory)
+Maybe<T> Or(Maybe<T> fallback)
+Maybe<T> Or(Func<Maybe<T>> fallbackFactory)
+Maybe<T> Where(Func<T, bool> predicate)
+Maybe<T> Tap(Action<T> action)
 TResult Match<TResult>(Func<T, TResult> some, Func<TResult> none)
 implicit operator Maybe<T>(T value)  // T → Maybe<T> (implicit)
 // No implicit conversion from Maybe<T> → T (by design — use .Value, Match, or TryGetValue)
@@ -207,6 +215,24 @@ ValueTask<Result<T>> ToResultAsync<T>(this ValueTask<T?> valueTask, Error) where
 ValueTask<Result<T>> ToResultAsync<T>(this ValueTask<T?> valueTask, Func<Error>) where T : struct
 ValueTask<Result<T>> ToResultAsync<T>(this ValueTask<T?> valueTask, Error) where T : class
 ValueTask<Result<T>> ToResultAsync<T>(this ValueTask<T?> valueTask, Func<Error>) where T : class
+```
+
+### Collection Helpers — Safe Enumerable → Maybe
+
+Extension methods on `IEnumerable<T>` for safely extracting elements as `Maybe<T>`, and filtering/unwrapping collections of `Maybe<T>`.
+
+```csharp
+// TryFirst — safe first element (no exception on empty)
+Maybe<T> TryFirst<T>(this IEnumerable<T>) where T : notnull
+Maybe<T> TryFirst<T>(this IEnumerable<T>, Func<T, bool> predicate) where T : notnull
+
+// TryLast — safe last element (no exception on empty)
+Maybe<T> TryLast<T>(this IEnumerable<T>) where T : notnull
+Maybe<T> TryLast<T>(this IEnumerable<T>, Func<T, bool> predicate) where T : notnull
+
+// Choose — filter and unwrap Maybe collections (like Seq.choose in F#)
+IEnumerable<T> Choose<T>(this IEnumerable<Maybe<T>>) where T : notnull
+IEnumerable<TResult> Choose<T, TResult>(this IEnumerable<Maybe<T>>, Func<T, TResult>)
 ```
 
 ---
@@ -351,6 +377,18 @@ Result<TOut> Map<TIn, TOut>(this Result<TIn>, Func<TIn, TOut>)
 // + 6 async variants (same pattern as Bind)
 ```
 
+### MapIf — Conditional Pure Transformation
+
+Transforms value only when a condition is met, otherwise passes through unchanged. Short-circuits on failure. Useful for optional transformations in pipelines without branching into `When`/`Unless`.
+
+```csharp
+// Static condition
+Result<T> MapIf<T>(this Result<T>, bool condition, Func<T, T> func)
+
+// Value-based predicate
+Result<T> MapIf<T>(this Result<T>, Func<T, bool> predicate, Func<T, T> func)
+```
+
 ### Ensure — Add Validation
 
 Validates value, returns failure if predicate fails. Short-circuits on prior failure.
@@ -391,6 +429,36 @@ var result = Result.Success(request)
         (r => r.Age >= 18, Error.Validation("Must be 18+", "age")),
         (r => r.Email.Contains('@'), Error.Validation("Invalid email", "email")));
 // Returns ONE ValidationError with all 3 field errors if all fail
+```
+
+### EnsureNotNull — Null-Guard + Type Narrowing
+
+Validates that a nullable value is not null, narrowing `Result<T?>` to `Result<T>`. Returns the supplied error on null. Supports both reference and value types.
+
+```csharp
+Result<T> EnsureNotNull<T>(this Result<T?>, Error error) where T : class
+Result<T> EnsureNotNull<T>(this Result<T?>, Error error) where T : struct
+```
+
+### Check — Validate Without Losing Pipeline Value
+
+Runs a validation function that returns a Result, but discards the inner value and keeps the original pipeline value on success. Useful for "fire a validation, keep the current value" patterns — like `Ensure`, but the validation itself is expressed as a `Result`-returning function.
+
+```csharp
+Result<T> Check<T, TK>(this Result<T>, Func<T, Result<TK>>)
+Result<T> Check<T>(this Result<T>, Func<T, Result<Unit>>)
+// Async: CheckAsync with Task/ValueTask Left/Right/Both variants
+```
+
+### BindZip — Sequential Tuple Accumulation
+
+Binds a function over the current value and zips the original value with the new result into a tuple. Enables sequential accumulation of values through a pipeline without nested closures. T4-generated overloads support growing tuples from 2 up to 9 elements.
+
+```csharp
+Result<(T1, T2)> BindZip<T1, T2>(this Result<T1>, Func<T1, Result<T2>>)
+// T4-generated: tuple continuation overloads (2 → 9 tuples)
+// e.g., Result<(T1, T2, T3)> BindZip<T1, T2, T3>(this Result<(T1, T2)>, Func<T1, T2, Result<T3>>)
+// Async: BindZipAsync with Task/ValueTask Left/Right/Both variants
 ```
 
 ### Tap — Side Effects on Success
@@ -645,6 +713,16 @@ Result<T> DebugOnFailure<T>(this Result<T>, Action<Error>)
 // + async variants
 ```
 
+### GetValueOrDefault — Terminal Extraction
+
+Extracts the value from a successful Result or returns a default/fallback. Terminal operator — exits the ROP pipeline. Supports static defaults, lazy factories, and error-aware factories.
+
+```csharp
+TValue GetValueOrDefault<TValue>(this Result<TValue>, TValue defaultValue)
+TValue GetValueOrDefault<TValue>(this Result<TValue>, Func<TValue> defaultFactory)
+TValue GetValueOrDefault<TValue>(this Result<TValue>, Func<Error, TValue> defaultFactory)
+```
+
 ## OpenTelemetry Tracing
 
 ROP operations automatically create `Activity` spans when instrumentation is enabled. Each `Bind`, `Map`, `Tap`, `Ensure`, `RecoverOnFailure`, and `Combine` call starts a child activity with success/error status.
@@ -775,6 +853,16 @@ static abstract Result<TSelf> TryCreate(TPrimitive value, string? fieldName = nu
 static virtual TSelf Create(TPrimitive value)  // default: TryCreate + throw
 TPrimitive Value { get; }
 ```
+
+## IFormattableScalarValue\<TSelf, TPrimitive\> (interface)
+
+Extends `IScalarValue` with culture-aware string parsing. Implemented by numeric and date value objects where culture affects string parsing (decimal separators, date formats).
+
+```csharp
+static abstract Result<TSelf> TryCreate(string? value, IFormatProvider? provider, string? fieldName = null);
+```
+
+Implementors: `Age`, `MonetaryAmount`, `Percentage` (hand-implemented), `RequiredInt<T>`, `RequiredDecimal<T>`, `RequiredLong<T>`, `RequiredDateTime<T>` (source-generated). Not implemented by string-based types (`EmailAddress`, `Slug`, etc.) — culture doesn't affect their parsing.
 
 ## Specification\<T\> (abstract class)
 
@@ -1138,7 +1226,27 @@ All have `TryCreate` → `Result<T>` and `Create` → `T` (throws). All implemen
 | `LanguageCode` | `string` | 2 letters, ISO 639-1, lowercase | — |
 | `Age` | `int` | 0–150 inclusive | — |
 | `Percentage` | `decimal` | 0–100 inclusive | `Zero`, `Full`, `AsFraction()`, `Of(decimal)`, `FromFraction(decimal, fieldName?)`, `TryCreate(decimal?)` |
+| `MonetaryAmount` | `decimal` | Non-negative, rounds to 2 dp | `Zero`, `Add`, `Subtract`, `Multiply(int)`, `Multiply(decimal)` |
 | `Money` | multi-value | Amount ≥ 0, valid currency code | See below |
+
+### MonetaryAmount (extends ScalarValueObject)
+
+Scalar value object for single-currency systems where currency is a system-wide policy, not per-row data. Wraps a non-negative `decimal` rounded to 2 decimal places. JSON: plain number (e.g. `99.99`). EF Core: maps to 1 `decimal` column (via `ApplyTrellisConventions`).
+
+```csharp
+// Implements: ScalarValueObject<MonetaryAmount, decimal>, IScalarValue<MonetaryAmount, decimal>, IParsable<MonetaryAmount>
+
+static Result<MonetaryAmount> TryCreate(decimal value)
+static Result<MonetaryAmount> TryCreate(decimal? value)
+static MonetaryAmount Create(decimal value)
+static MonetaryAmount Zero { get; }
+
+// Arithmetic (returns Result — handles overflow)
+Result<MonetaryAmount> Add(MonetaryAmount other)
+Result<MonetaryAmount> Subtract(MonetaryAmount other)
+Result<MonetaryAmount> Multiply(int quantity)
+Result<MonetaryAmount> Multiply(decimal multiplier)
+```
 
 ### Money (extends ValueObject, NOT ScalarValueObject)
 
@@ -1193,16 +1301,14 @@ string? GetAttribute(string key)
 
 ## Interfaces
 
-- **`IActorProvider`** — Provides the current authenticated actor synchronously (from JWT claims).
-- **`IAsyncActorProvider`** — Async variant for when permission resolution requires I/O.
+- **`IActorProvider`** — Provides the current authenticated actor asynchronously. Unified interface for all actor resolution (JWT claims, database lookups, etc.).
 - **`IAuthorize`** — Declares required permissions; checked by authorization pipeline behavior.
 - **`IAuthorizeResource<TResource>`** — Resource-based authorization; receives the loaded resource and actor.
 - **`IResourceLoader<TMessage, TResource>`** — Loads the resource for resource-based authorization checks.
 - **`ResourceLoaderById<TMessage, TResource, TId>`** — Base class for the common "extract ID from message, load by ID" pattern.
 
 ```csharp
-interface IActorProvider { Actor GetCurrentActor(); }
-interface IAsyncActorProvider { Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default); }
+interface IActorProvider { Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default); }
 interface IAuthorize { IReadOnlyList<string> RequiredPermissions { get; } }
 interface IAuthorizeResource<TResource> { IResult Authorize(Actor actor, TResource resource); }
 interface IResourceLoader<TMessage, TResource> { Task<Result<TResource>> LoadAsync(TMessage message, CancellationToken cancellationToken); }
@@ -1212,19 +1318,6 @@ abstract class ResourceLoaderById<TMessage, TResource, TId> : IResourceLoader<TM
     protected abstract Task<Result<TResource>> GetByIdAsync(TId id, CancellationToken cancellationToken);
 }
 ```
-
-### IAsyncActorProvider
-
-Asynchronous variant of `IActorProvider`. Use when permission resolution requires async operations such as database lookups or external service calls.
-
-```csharp
-public interface IAsyncActorProvider
-{
-    Task<Actor> GetCurrentActorAsync(CancellationToken cancellationToken = default);
-}
-```
-
-Use `IActorProvider` when the actor can be resolved synchronously (e.g., from in-memory claims). Use `IAsyncActorProvider` when resolution requires I/O (e.g., loading permissions from a database).
 
 ## ActorAttributes Constants
 
@@ -1389,9 +1482,25 @@ Benefits: Native AOT compatible, no reflection, trimming-safe, faster startup.
 
 **Namespace: `Trellis.Asp.Authorization`**
 
+## ClaimsActorProvider (Generic OIDC/JWT)
+
+Generic actor provider that maps standard OIDC/JWT claims to an `Actor`. Works with any identity provider (Auth0, Keycloak, Okta, Entra, etc.).
+
+```csharp
+// Registration
+services.AddClaimsActorProvider();
+services.AddClaimsActorProvider(options => {
+    options.ActorIdClaim = "sub";           // default: "sub"
+    options.PermissionsClaim = "permissions"; // default: "permissions"
+});
+
+// ClaimsActorProvider : IActorProvider
+// Extracts Actor from HttpContext claims using configurable claim names
+```
+
 ## EntraActorProvider (Production)
 
-Production actor provider that maps Microsoft Entra ID (Azure AD) JWT claims to an `Actor`. Extracts user ID from `sub` claim and permissions from roles/scopes claims.
+Production actor provider that maps Microsoft Entra ID (Azure AD) JWT claims to an `Actor`. Extends `ClaimsActorProvider` with Entra-specific claim mapping for permissions, forbidden permissions, and ABAC attributes.
 
 ```csharp
 // Registration
@@ -1401,13 +1510,13 @@ services.AddEntraActorProvider(options => {
     options.MapPermissions = claims => /* custom extraction */;
 });
 
-// EntraActorProvider : IActorProvider
+// EntraActorProvider : ClaimsActorProvider
 // Extracts Actor from HttpContext claims (Entra ID / Azure AD)
 ```
 
 ## DevelopmentActorProvider (Development/Testing)
 
-Development/testing actor provider that reads `Actor` from the `X-Test-Actor` HTTP header (JSON). Falls back to a configurable default actor. Throws in Production to prevent accidental use.
+Development/testing actor provider that reads `Actor` from the `X-Test-Actor` HTTP header (JSON). Falls back to a configurable default actor. **Throws unconditionally in any non-Development environment** to prevent accidental use in Production.
 
 ```csharp
 // Registration — for development environments
@@ -1419,8 +1528,8 @@ services.AddDevelopmentActorProvider(options => {
 });
 
 // DevelopmentActorProvider : IActorProvider
-// Reads Actor from X-Test-Actor HTTP header (JSON)
-// Throws InvalidOperationException if header present in Production
+// Throws InvalidOperationException unconditionally in non-Development environments
+// Reads Actor from X-Test-Actor HTTP header (JSON) in Development
 // Falls back to configurable default Actor when header absent
 // Header JSON schema: { "Id": "...", "Permissions": [...], "ForbiddenPermissions": [...], "Attributes": {...} }
 
@@ -1431,13 +1540,40 @@ else
     services.AddEntraActorProvider();
 ```
 
+## CachingActorProvider (Decorator)
+
+Caching decorator that wraps any `IActorProvider` and caches the result per-scope. Use with database-backed providers to avoid redundant queries within a single request.
+
+```csharp
+// Registration — wraps DatabaseActorProvider with per-request caching
+services.AddCachingActorProvider<DatabaseActorProvider>();
+
+// CachingActorProvider : IActorProvider
+// Caches the Task<Actor> from the first call; subsequent calls return the same result
+```
+
 | Type | Purpose |
 |------|---------|
-| `EntraActorProvider` | Production — maps Entra JWT claims to `Actor` |
+| `ClaimsActorProvider` | Generic OIDC/JWT — maps configurable claims to `Actor` |
+| `ClaimsActorOptions` | Configuration for generic claim mapping (`ActorIdClaim`, `PermissionsClaim`) |
+| `EntraActorProvider` | Production — maps Entra JWT claims to `Actor` (extends `ClaimsActorProvider`) |
 | `EntraActorOptions` | Configuration for Entra claim mapping |
 | `DevelopmentActorProvider` | Development/testing — reads `X-Test-Actor` header |
 | `DevelopmentActorOptions` | Configuration for default actor and error handling |
-| `ServiceCollectionExtensions` | `AddEntraActorProvider()` and `AddDevelopmentActorProvider()` |
+| `CachingActorProvider` | Decorator — caches inner provider per-scope |
+| `ServiceCollectionExtensions` | `AddClaimsActorProvider()`, `AddEntraActorProvider()`, `AddDevelopmentActorProvider()`, `AddCachingActorProvider<T>()` |
+
+### ClaimsActorOptions
+
+Configures how `ClaimsActorProvider` extracts actor identity from JWT claims.
+
+```csharp
+public class ClaimsActorOptions
+{
+    string ActorIdClaim { get; set; }     // default: "sub"
+    string PermissionsClaim { get; set; } // default: "permissions"
+}
+```
 
 ### EntraActorOptions
 
@@ -1672,6 +1808,7 @@ IQueryable<T> Where<T>(this IQueryable<T> query, Specification<T> specification)
 configurationBuilder.ApplyTrellisConventions(typeof(Order).Assembly);
 // Auto-registers converters for all IScalarValue and RequiredEnum types
 // Auto-maps Money properties as owned types (Amount + Currency columns)
+// MonetaryAmount maps to a single decimal column (scalar value object convention)
 ```
 
 ### Money Property Convention
@@ -1684,6 +1821,8 @@ configurationBuilder.ApplyTrellisConventions(typeof(Order).Assembly);
 | `ShippingCost` | `ShippingCost` | `ShippingCostCurrency` | `decimal(18,3)` | `nvarchar(3)` |
 
 Explicit `OwnsOne` configuration takes precedence over the convention.
+
+`Maybe<Money>` properties are also supported — `MaybeConvention` creates an optional ownership navigation with nullable Amount/Currency columns. No manual `OwnsOne` needed.
 
 ### Maybe\<T\> Property Mapping
 
@@ -1707,7 +1846,7 @@ modelBuilder.Entity<Customer>(b =>
 });
 ```
 
-The source generator emits a private `_camelCase` backing field and getter/setter for each `partial Maybe<T>` property. The `MaybeConvention` (registered by `ApplyTrellisConventions`) auto-discovers `Maybe<T>` properties, ignores the struct property, maps the backing field as nullable, and sets the column name to the property name.
+The source generator emits a private `_camelCase` backing field and getter/setter for each `partial Maybe<T>` property. The `MaybeConvention` (registered by `ApplyTrellisConventions`) auto-discovers `Maybe<T>` properties, ignores the struct property, maps the backing field as nullable, and sets the column name to the property name. When `T` is a composite owned type (e.g., `Money`), `MaybeConvention` creates an optional ownership navigation instead of a scalar column.
 
 Backing field naming: `Phone` → `_phone`, `SubmittedAt` → `_submittedAt`, `AlternateEmail` → `_alternateEmail`.
 
@@ -1899,6 +2038,9 @@ UpdateSettersBuilder<TEntity> SetMaybeValue<TEntity, TInner>(
 UpdateSettersBuilder<TEntity> SetMaybeNone<TEntity, TInner>(
     this UpdateSettersBuilder<TEntity> updateSettersBuilder,
     Expression<Func<TEntity, Maybe<TInner>>> propertySelector)
+
+// Note: SetMaybeValue/SetMaybeNone throw InvalidOperationException for composite
+// owned types like Money. Use tracked entity updates (load, modify, SaveChangesAsync) instead.
 
 // Diagnostics
 IReadOnlyList<MaybePropertyMapping> GetMaybePropertyMappings(this IModel model)

--- a/template/.github/trellis-api-reference.md
+++ b/template/.github/trellis-api-reference.md
@@ -2334,14 +2334,14 @@ Complete example showing how to model optional fields with `Maybe<T>` in request
 public record CreateProfileRequest(
     string Email,
     string FirstName,
-    Maybe<string> MiddleName,    // optional
+    string? MiddleName,    // optional
     string LastName,
-    Maybe<Url> Website           // optional value object
+    Url? Website           // optional value object
 );
 
 // Validation with Optional
 var result = EmailAddress.TryCreate(dto.Email)
-    .Combine(Maybe.Optional(dto.MiddleName.AsNullable(), MiddleName.TryCreate))
+    .Combine(Maybe.Optional(dto.MiddleName, MiddleName.TryCreate))
     .Bind((email, middleName) => CreateProfile(email, middleName));
 
 // EF Core persistence — use partial Maybe<T> property (see §12 Maybe<T> Property Mapping)
@@ -2359,26 +2359,22 @@ Complete example showing how to map `Result<T>` to HTTP responses in both MVC co
 ```csharp
 // MVC Controller
 [HttpGet("{id}")]
-public async Task<ActionResult<OrderDto>> GetOrder(string id)
+public async Task<ActionResult<OrderDto>> GetOrder(OrderId id)
 {
-    return await OrderId.TryCreate(id)
-        .BindAsync(orderId => _service.GetOrderAsync(orderId))
-        .MapAsync(order => order.ToDto())
-        .ToActionResultAsync(this);
+    return await _service.GetOrderAsync(id)
+        .ToActionResultAsync(this, OrderDto.From);
 }
 
 [HttpPost]
 public async Task<ActionResult<OrderDto>> CreateOrder(CreateOrderRequest request)
 {
     return await _service.CreateOrderAsync(request)
-        .MapAsync(order => order.ToDto())
-        .ToCreatedAtActionResultAsync(this, nameof(GetOrder), dto => new { id = dto.Id });
+        .ToCreatedAtActionResultAsync(this, nameof(GetOrder), dto => new { id = dto.Id }, OrderDto.From);
 }
 
 // Minimal API
-app.MapGet("/orders/{id}", async (string id, IOrderService service) =>
-    await OrderId.TryCreate(id)
-        .BindAsync(orderId => service.GetOrderAsync(orderId))
+app.MapGet("/orders/{id}", async (OrderId id, IOrderService service) =>
+    await service.GetOrderAsync(id)
         .MapAsync(order => order.ToDto())
         .ToHttpResultAsync());
 ```
@@ -2411,8 +2407,8 @@ public async Task<Result<Order>> GetByIdAsync(OrderId id, CancellationToken canc
     await _dbContext.Orders
         .FirstOrDefaultResultAsync(o => o.Id == id, Error.NotFound($"Order {id} not found"), ct);
 
-public async Task<Result<Maybe<Order>>> FindByIdAsync(OrderId id, CancellationToken cancellationToken) =>
-    Result.Success(await _dbContext.Orders.FirstOrDefaultMaybeAsync(o => o.Id == id, ct));
+public async Task<Maybe<Order>> FindByIdAsync(OrderId id, CancellationToken cancellationToken) =>
+    await _dbContext.Orders.FirstOrDefaultMaybeAsync(o => o.Id == id, ct);
 
 public async Task<Result<Unit>> SaveAsync(Order order, CancellationToken cancellationToken)
 {
@@ -2435,7 +2431,8 @@ In LINQ queries, compare value objects to value objects — the value converter 
 var customer = await _dbContext.Customers
     .FirstOrDefaultResultAsync(c => c.Email == EmailAddress.Create("alice@example.com"), notFoundError, ct);
 
-// ❌ Wrong — .Value won't translate to SQL
+// ✅ Also correct (with ScalarValueQueryInterceptor registered via AddTrellisInterceptors)
+// The interceptor rewrites .Value access to the primitive for SQL translation
 var customer = await _dbContext.Customers
     .FirstOrDefaultResultAsync(c => c.Email.Value == "alice@example.com", notFoundError, ct);
 ```

--- a/template/.github/trellis-api-testing-reference.md
+++ b/template/.github/trellis-api-testing-reference.md
@@ -4,14 +4,6 @@
 > fake repositories, actor providers, and testing patterns for Trellis applications.
 > For the core framework API, see `trellis-api-reference.md`.
 
-## Namespaces
-
-```csharp
-using Trellis.Testing;          // Assertions, WebApplicationFactory extensions, MSAL types
-using Trellis.Testing.Builders; // ResultBuilder, ValidationErrorBuilder
-using Trellis.Testing.Fakes;    // FakeRepository, TestActorProvider, TestActorScope
-```
-
 ---
 
 ## Result Assertions
@@ -27,7 +19,7 @@ result.Should().HaveErrorCode("not.found")
 result.Should().HaveErrorDetail("Order not found")
 result.Should().HaveErrorDetailContaining("not found")
 
-// Async — works with both Task<Result<T>> and ValueTask<Result<T>>
+// Async
 await result.Should().BeSuccessAsync()
 await result.Should().BeFailureAsync()
 await result.Should().BeFailureOfTypeAsync<ValidationError>()
@@ -72,7 +64,7 @@ validationError.Should().HaveFieldCount(2)
 ResultBuilder.Success(value)
 ResultBuilder.Failure<T>(error)
 ResultBuilder.NotFound<T>("Order not found")
-ResultBuilder.NotFound<T>("Order", "123")      // "Order 123 not found"
+ResultBuilder.NotFound<T>("Order", "123")      // "Order '123' not found"
 ResultBuilder.Validation<T>("Invalid", "field")
 ResultBuilder.Unauthorized<T>()
 ResultBuilder.Forbidden<T>()
@@ -97,43 +89,33 @@ In-memory repository for Application-layer handler tests. Stores entities in a d
 // Construction
 var repo = new FakeRepository<Order, OrderId>();
 
-// Unique constraint — SaveAsync returns ConflictError on duplicate
-repo.WithUniqueConstraint(o => o.Email);
-
 // CRUD operations
-await repo.SaveAsync(order);                               // Result<Unit> (ConflictError if unique violation)
-var result = await repo.GetByIdAsync(orderId);             // Result<Order> (NotFound if missing)
-var maybe = await repo.FindByIdAsync(orderId);             // Result<Maybe<Order>>
-await repo.DeleteAsync(orderId);                           // Result<Unit> (NotFound if missing)
+await repo.SaveAsync(order);
+var result = await repo.GetByIdAsync(orderId);        // Result<Order> (NotFound if missing)
+var maybe = await repo.FindByIdAsync(orderId);        // Result<Maybe<Order>>
+await repo.DeleteAsync(orderId);
 
-// Synchronous helpers for test setup and assertions
-repo.Clear();                                              // Remove all entities
-bool exists = repo.Exists(orderId);                        // Check existence
-Order? order = repo.Get(orderId);                          // Get or null (no Result)
-IEnumerable<Order> all = repo.GetAll();                    // All stored entities
-int count = repo.Count;                                    // Number of stored entities
+// Seeding test data
+var order = Order.Create(...);
+await repo.SaveAsync(order);                           // Now GetByIdAsync will return it
 
 // Domain event inspection
-repo.PublishedEvents                                       // IReadOnlyList<IDomainEvent>
+repo.PublishedEvents                                   // IReadOnlyList<IDomainEvent>
 ```
 
 ## TestActorProvider and TestActorScope
 
 **Namespace: `Trellis.Testing.Fakes`**
 
-Mutable `IActorProvider` and `IAsyncActorProvider` for authorization testing. Uses `AsyncLocal<Actor?>` internally so parallel tests sharing a singleton provider never interfere. `WithActor` returns a scope that restores the previous actor on dispose, eliminating `try/finally` boilerplate.
+Mutable `IActorProvider` for authorization testing. Uses `AsyncLocal<Actor?>` internally so parallel tests sharing a singleton provider never interfere. `WithActor` returns a scope that restores the previous actor on dispose, eliminating `try/finally` boilerplate.
 
-Implements both `IActorProvider` (sync) and `IAsyncActorProvider` (async). Register as both interfaces in DI when the system under test uses `IAsyncActorProvider`.
+Implements `IActorProvider` with `GetCurrentActorAsync()` returning `Task.FromResult()`. Register as `IActorProvider` in DI.
 
 ### Construction
 
 ```csharp
 var actorProvider = new TestActorProvider("admin", "Orders.Read", "Orders.Write");
 var actorFromInstance = new TestActorProvider(actor);               // from Actor instance
-
-// Access the current actor (implements IActorProvider and IAsyncActorProvider)
-Actor actor = actorProvider.GetCurrentActor();
-Actor actor = await actorProvider.GetCurrentActorAsync(cancellationToken);
 ```
 
 ### Scoped Actor Switching
@@ -184,56 +166,48 @@ Creates an `HttpClient` with the `X-Test-Actor` header pre-set, encoding actor i
 // Extension on WebApplicationFactory<TEntryPoint>
 var client = factory.CreateClientWithActor("user-1", "Orders.Create", "Orders.Read");
 // Sets header: X-Test-Actor: {"Id":"user-1","Permissions":["Orders.Create","Orders.Read"]}
-
-// Overload with full Actor object (for ForbiddenPermissions, Attributes)
-var actor = Actor.Create("user-1", new HashSet<string> { "Orders.Create" });
-var client = factory.CreateClientWithActor(actor);
-```
-
-The full Actor JSON shape supports `ForbiddenPermissions` and `Attributes` in addition to `Id` and `Permissions`:
-```json
-{
-  "Id": "user-1",
-  "Permissions": ["Orders.Create", "Orders.Read"],
-  "ForbiddenPermissions": ["Orders.Delete"],
-  "Attributes": { "tenantId": "tenant-42" }
-}
 ```
 
 ---
 
-## MSAL E2E Test Support
+## ReplaceDbProvider
 
-**Namespace: `Trellis.Testing`**
-
-For end-to-end tests against a real Entra ID (Azure AD) tenant. Acquires real tokens using ROPC (Resource Owner Password Credentials) flow.
+Cleanly swaps the EF Core database provider in `WebApplicationFactory` tests. Removes all EF Core internal services for the context (including `IDbContextOptionsConfiguration<TContext>` in EF Core 10) and re-registers with the new provider.
 
 ```csharp
-// Configuration
-public sealed class MsalTestOptions
-{
-    public string TenantId { get; set; }
-    public string ClientId { get; set; }
-    public string[] Scopes { get; set; }
-    public Dictionary<string, TestUserCredentials> TestUsers { get; set; }
-}
-
-public sealed class TestUserCredentials
-{
-    public string Username { get; set; }
-    public string Password { get; set; }
-    public string[] ExpectedPermissions { get; set; }
-}
-
-// Token acquisition
-var tokenProvider = new MsalTestTokenProvider(msalOptions);
-string token = await tokenProvider.AcquireTokenAsync("admin-user", cancellationToken);
-
-// WebApplicationFactory extension — creates client with real Bearer token
-var client = await factory.CreateClientWithEntraTokenAsync(tokenProvider, "admin-user", cancellationToken);
+// In TestWebApplicationFactoryFixture.ConfigureWebHost
+builder.ConfigureServices(services =>
+    services.ReplaceDbProvider<AppDbContext>(options =>
+        options.UseSqlite(_connection).AddTrellisInterceptors()));
 ```
 
-> ⚠️ MSAL types use reflection and are not AOT-compatible.
+> **Limitation:** Always re-registers via `AddDbContext<TContext>`. If the application uses `AddDbContextFactory` or `AddPooledDbContextFactory`, swap providers manually instead of using this helper.
+
+---
+
+## ClaimsActorProvider and CachingActorProvider in Tests
+
+For integration tests using `WebApplicationFactory`, the `DevelopmentActorProvider` (via `X-Test-Actor` header) is the standard approach. `ClaimsActorProvider` and `CachingActorProvider` are production providers — they read from `HttpContext.User` which requires real authentication middleware.
+
+If your tests need to exercise `ClaimsActorProvider` directly, construct a `ClaimsPrincipal` and set it on `HttpContext.User`:
+
+```csharp
+var identity = new ClaimsIdentity(new[]
+{
+    new Claim("sub", "user-1"),
+    new Claim("permissions", "orders:read"),
+}, "Bearer");
+var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+```
+
+For `CachingActorProvider`, register via DI using `AddCachingActorProvider<T>()`. For unit tests, construct with an `IHttpContextAccessor`:
+
+```csharp
+var inner = new TestActorProvider("user-1", "orders:read");
+var accessor = new HttpContextAccessor(); // no HttpContext in unit tests — uses CancellationToken.None
+var caching = new CachingActorProvider(inner, accessor);
+var actor = await caching.GetCurrentActorAsync(ct);  // calls inner once, caches
+```
 
 ---
 
@@ -343,132 +317,3 @@ public async Task Cancel_ByNonOwner_ReturnsForbidden()
     result.Should().BeFailureOfType<ForbiddenError>();
 }
 ```
-
-### Conflict/Uniqueness Test
-
-```csharp
-[Fact]
-public async Task Save_duplicate_email_returns_conflict()
-{
-    var repo = new FakeRepository<Customer, CustomerId>();
-    repo.WithUniqueConstraint(c => c.Email);
-
-    var customer1 = Customer.TryCreate(email: EmailAddress.Create("a@b.com")).Value;
-    await repo.SaveAsync(customer1);
-
-    var customer2 = Customer.TryCreate(email: EmailAddress.Create("a@b.com")).Value;
-    var result = await repo.SaveAsync(customer2);
-
-    result.Should().BeFailureOfType<ConflictError>();
-}
-```
-
-### Maybe Query Test
-
-```csharp
-[Fact]
-public async Task FindById_missing_returns_none()
-{
-    var repo = new FakeRepository<Order, OrderId>();
-
-    var result = await repo.FindByIdAsync(OrderId.NewUniqueV7());
-
-    result.Should().BeSuccess();
-    result.Value.Should().BeNone();
-}
-
-[Fact]
-public async Task FindById_existing_returns_value()
-{
-    var repo = new FakeRepository<Order, OrderId>();
-    var order = Order.TryCreate(...).Value;
-    await repo.SaveAsync(order);
-
-    var result = await repo.FindByIdAsync(order.Id);
-
-    result.Should().BeSuccess();
-    result.Value.Should().HaveValue();
-}
-```
-
-### State Machine Transition Test
-
-```csharp
-[Fact]
-public void Valid_transition_returns_new_state()
-{
-    var todo = TodoItem.TryCreate(title, dueDate, tag, actorId).Value;
-    todo.Start().Should().BeSuccess();
-
-    var result = todo.Complete();
-
-    result.Should().BeSuccess()
-        .Which.Should().Be(TodoStatus.Completed);
-}
-
-[Fact]
-public void Invalid_transition_returns_failure()
-{
-    var todo = TodoItem.TryCreate(title, dueDate, tag, actorId).Value;
-    // Skip Start — try to Complete from Pending
-
-    var result = todo.Complete();
-
-    result.Should().BeFailure();
-}
-```
-
-### Domain Event Assertions
-
-```csharp
-[Fact]
-public async Task Save_publishes_domain_events()
-{
-    var repo = new FakeRepository<Order, OrderId>();
-    var order = Order.TryCreate(customerId).Value;
-    await repo.SaveAsync(order);
-
-    repo.PublishedEvents.Should().ContainSingle()
-        .Which.Should().BeOfType<OrderCreated>();
-}
-```
-
-### HTTP Authorization Matrix
-
-Test all permission scenarios for an endpoint:
-
-```csharp
-[Fact]
-public async Task Complete_by_owner_returns_200()
-{
-    var client = factory.CreateClientWithActor("owner-1", "todos:complete");
-    // ... create todo as owner-1, then complete
-    response.StatusCode.Should().Be(HttpStatusCode.OK);
-}
-
-[Fact]
-public async Task Complete_by_non_owner_returns_403()
-{
-    // ... create todo as owner-1
-    var client = factory.CreateClientWithActor("other-user", "todos:complete");
-    response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
-}
-
-[Fact]
-public async Task Complete_without_permission_returns_403()
-{
-    var client = factory.CreateClientWithActor("owner-1"); // no todos:complete permission
-    response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
-}
-```
-
-### Decision Table — When to Use What
-
-| Scenario | Tool | Why |
-|----------|------|-----|
-| Domain unit tests (value objects, aggregates, specs) | Direct construction, no DI | Pure logic, no infrastructure |
-| Handler tests (commands, queries) | `FakeRepository` + `TestActorProvider` + `ISender` via DI | Tests handler logic with mocked persistence and auth |
-| Authorization tests | `TestActorProvider.WithActor(...)` scoped switching | Tests permission and ownership checks |
-| Resource authorization tests | `ReplaceResourceLoader(...)` + `TestActorProvider` | Tests `IAuthorizeResource<T>` pipeline |
-| API integration tests | `WebApplicationFactory` + `CreateClientWithActor(...)` | Tests full HTTP round-trip with real middleware |
-| E2E with real Entra ID | `CreateClientWithEntraTokenAsync(...)` + `MsalTestTokenProvider` | Tests against real identity provider |

--- a/template/Acl/src/CompleteTodoResourceLoader.cs
+++ b/template/Acl/src/CompleteTodoResourceLoader.cs
@@ -21,6 +21,5 @@ internal class CompleteTodoResourceLoader : ResourceLoaderById<CompleteTodoComma
             .Where(t => t.Id == id)
             .FirstOrDefaultResultAsync(
                 Error.NotFound($"Todo item {id.Value} not found."),
-                cancellationToken)
-            .ConfigureAwait(false);
+                cancellationToken);
 }

--- a/template/Acl/src/TodoRepository.cs
+++ b/template/Acl/src/TodoRepository.cs
@@ -14,22 +14,13 @@ internal class TodoRepository : ITodoRepository
 
     public TodoRepository(AppDbContext context) => _context = context;
 
-    public async Task<Maybe<TodoItem>> FindByIdAsync(TodoId id, CancellationToken cancellationToken)
-    {
-        var entity = await _context.TodoItems
-            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken)
-            .ConfigureAwait(false);
-        return Maybe.From(entity);
-    }
+    public async Task<Maybe<TodoItem>> FindByIdAsync(TodoId id, CancellationToken cancellationToken) =>
+        await _context.TodoItems.FirstOrDefaultMaybeAsync(t => t.Id == id, cancellationToken);
 
-    public async Task<IReadOnlyList<TodoItem>> GetAllAsync(Specification<TodoItem> specification, CancellationToken cancellationToken)
-    {
-        var items = await _context.TodoItems
+    public async Task<IReadOnlyList<TodoItem>> GetAllAsync(Specification<TodoItem> specification, CancellationToken cancellationToken) =>
+        await _context.TodoItems
             .Where(specification)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-        return items;
-    }
+            .ToListAsync(cancellationToken);
 
     public async Task<Result<Unit>> SaveAsync(TodoItem todo, CancellationToken cancellationToken)
     {
@@ -37,7 +28,7 @@ internal class TodoRepository : ITodoRepository
         if (entry.State == EntityState.Detached)
             _context.TodoItems.Add(todo);
 
-        return await _context.SaveChangesResultUnitAsync(cancellationToken).ConfigureAwait(false);
+        return await _context.SaveChangesResultUnitAsync(cancellationToken);
     }
 
     public async Task<Result<Unit>> DeleteAsync(TodoId id, CancellationToken cancellationToken)

--- a/template/Api/src/2026-03-26/Models/TodoResponse.cs
+++ b/template/Api/src/2026-03-26/Models/TodoResponse.cs
@@ -38,7 +38,7 @@ public record TodoResponse
         Title = todo.Title.Value,
         DueDate = todo.DueDate.Value,
         Status = todo.Status.ToString(),
-        CompletedAt = todo.CompletedAt.Match<DateTime?>(v => v, () => null),
+        CompletedAt = todo.CompletedAt.AsNullable(),
         Tag = todo.Tag.Match<string?>(t => t.Value, () => null),
         CreatedByActorId = todo.CreatedByActorId,
         CreatedAt = todo.CreatedAt

--- a/template/Api/tests/TestWebApplicationFixture/TestWebApplicationFactoryFixture.cs
+++ b/template/Api/tests/TestWebApplicationFixture/TestWebApplicationFactoryFixture.cs
@@ -4,12 +4,12 @@ using MartinCostello.Logging.XUnit;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using TodoSample.AntiCorruptionLayer;
 using Trellis.EntityFrameworkCore;
+using Trellis.Testing;
 using Xunit.v3;
 
 public class TestWebApplicationFactoryFixture : WebApplicationFactory<Program>, ITestOutputHelperAccessor
@@ -32,14 +32,9 @@ public class TestWebApplicationFactoryFixture : WebApplicationFactory<Program>, 
         builder.ConfigureLogging(p => p.AddXUnit(this));
 
         builder.ConfigureServices(services =>
-        {
-            // Remove the production database registration
-            services.RemoveAll<DbContextOptions<AppDbContext>>();
-
-            services.AddDbContext<AppDbContext>(options =>
+            services.ReplaceDbProvider<AppDbContext>(options =>
                 options.UseSqlite(_connection)
-                       .AddTrellisInterceptors());
-        });
+                       .AddTrellisInterceptors()));
     }
 
     protected override void Dispose(bool disposing)

--- a/template/Application/src/Todos/CompleteTodoCommand.cs
+++ b/template/Application/src/Todos/CompleteTodoCommand.cs
@@ -33,6 +33,6 @@ public sealed class CompleteTodoCommandHandler : ICommandHandler<CompleteTodoCom
         return await maybe
             .ToResult(Error.NotFound($"Todo {command.TodoId} not found."))
             .Bind(todo => todo.Complete().Map(_ => todo))
-            .BindAsync(todo => _repository.SaveAsync(todo, cancellationToken).MapAsync(_ => todo));
+            .CheckAsync(todo => _repository.SaveAsync(todo, cancellationToken));
     }
 }

--- a/template/Application/src/Todos/CreateTodoCommand.cs
+++ b/template/Application/src/Todos/CreateTodoCommand.cs
@@ -35,6 +35,6 @@ public sealed class CreateTodoCommandHandler : ICommandHandler<CreateTodoCommand
         var actor = await _actorProvider.GetCurrentActorAsync(cancellationToken);
         return await TodoItem.TryCreate(command.Title, command.DueDate, command.Tag, actor.Id)
             .Bind(todo => todo.Start().Map(_ => todo))
-            .BindAsync(todo => _repository.SaveAsync(todo, cancellationToken).MapAsync(_ => todo));
+            .CheckAsync(todo => _repository.SaveAsync(todo, cancellationToken));
     }
 }

--- a/template/Application/src/Todos/CreateTodoCommand.cs
+++ b/template/Application/src/Todos/CreateTodoCommand.cs
@@ -32,7 +32,7 @@ public sealed class CreateTodoCommandHandler : ICommandHandler<CreateTodoCommand
 
     public async ValueTask<Result<TodoItem>> Handle(CreateTodoCommand command, CancellationToken cancellationToken)
     {
-        var actor = _actorProvider.GetCurrentActor();
+        var actor = await _actorProvider.GetCurrentActorAsync(cancellationToken);
         return await TodoItem.TryCreate(command.Title, command.DueDate, command.Tag, actor.Id)
             .Bind(todo => todo.Start().Map(_ => todo))
             .BindAsync(todo => _repository.SaveAsync(todo, cancellationToken).MapAsync(_ => todo));

--- a/template/Application/src/Todos/UpdateTodoCommand.cs
+++ b/template/Application/src/Todos/UpdateTodoCommand.cs
@@ -55,6 +55,6 @@ public sealed class UpdateTodoCommandHandler : ICommandHandler<UpdateTodoCommand
         return await maybe
             .ToResult(Error.NotFound($"Todo {command.TodoId} not found."))
             .Bind(todo => todo.Update(command.Title, command.DueDate, command.Tag))
-            .BindAsync(todo => _repository.SaveAsync(todo, cancellationToken).MapAsync(_ => todo));
+            .CheckAsync(todo => _repository.SaveAsync(todo, cancellationToken));
     }
 }

--- a/template/Directory.Packages.props
+++ b/template/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrellisVersion>3.0.0-alpha.137</TrellisVersion>
+    <TrellisVersion>3.0.0-alpha.140</TrellisVersion>
   </PropertyGroup>
   <!-- Runtime -->
   <ItemGroup>


### PR DESCRIPTION
﻿Updates the Trellis framework dependency from 3.0.0-alpha.137 to 3.0.0-alpha.140 and adopts new framework features
throughout the template.

Breaking change fix

 - IActorProvider.GetCurrentActor() → GetCurrentActorAsync() in CreateTodoCommandHandler — the sync API was removed 
in alpha.140

New framework API adoption

 - FirstOrDefaultMaybeAsync — replaced manual FirstOrDefaultAsync + Maybe.From() in TodoRepository.FindByIdAsync
 - Maybe<T>.AsNullable() — replaced verbose Match<DateTime?>(v => v, () => null) in TodoResponse.From
 - ReplaceDbProvider<T> — replaced manual RemoveAll + AddDbContext in TestWebApplicationFactoryFixture, which also 
handles EF Core 10's IDbContextOptionsConfiguration<TContext> cleanup
