### PR TITLE
Update Trellis upgrade docs and test fixture config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -69,6 +69,16 @@ dotnet new trellis-asp -n MyService
 dotnet new uninstall Trellis.AspTemplate
 ```
 
+## Upgrading Trellis Packages
+
+After upgrading `TrellisVersion` in `template/Directory.Packages.props`, sync the API reference files:
+
+```powershell
+dotnet build template/Domain/src/Domain.csproj /t:TrellisSyncApiReference
+```
+
+This copies the updated `trellis-api-*.md` files from the NuGet packages into `template/.github/`. Verify the diff and commit the updated reference files alongside the version bump.
+
 ## Updating Trellis Conventions
 
 When updating how AI should build services with Trellis:

--- a/template/.github/copilot-instructions.md
+++ b/template/.github/copilot-instructions.md
@@ -606,6 +606,8 @@ services.AddScoped<IActorProvider, HttpActorProvider>();
 
 > **NuGet packages:** Add `<PackageVersion>` to `Directory.Packages.props`, then add `<PackageReference>` without a version in the relevant `.csproj`.
 
+> **Upgrading Trellis packages:** After changing `TrellisVersion` in `Directory.Packages.props`, run `dotnet build /t:TrellisSyncApiReference` to update the `.github/trellis-api-*.md` reference files from the new package versions.
+
 ### HTTP request documentation files
 
 - **Rule:** 🟡 SHOULD replace `Api/src/api.http` with end-to-end requests for every endpoint and keep complex header values in `Api/src/http-client.env.json` as escaped JSON strings.

--- a/template/.github/copilot-instructions.md
+++ b/template/.github/copilot-instructions.md
@@ -606,7 +606,7 @@ services.AddScoped<IActorProvider, HttpActorProvider>();
 
 > **NuGet packages:** Add `<PackageVersion>` to `Directory.Packages.props`, then add `<PackageReference>` without a version in the relevant `.csproj`.
 
-> **Upgrading Trellis packages:** After changing `TrellisVersion` in `Directory.Packages.props`, run `dotnet build /t:TrellisSyncApiReference` to update the `.github/trellis-api-*.md` reference files from the new package versions.
+> **Upgrading Trellis packages:** After changing `TrellisVersion` in `Directory.Packages.props`, run `dotnet build ./{ServiceName}.slnx /t:TrellisSyncApiReference` from the service repository root to update the `.github/trellis-api-*.md` reference files from the new package versions.
 
 ### HTTP request documentation files
 

--- a/template/Api/tests/TestWebApplicationFixture/TestWebApplicationFactoryFixture.cs
+++ b/template/Api/tests/TestWebApplicationFixture/TestWebApplicationFactoryFixture.cs
@@ -15,15 +15,20 @@ using Xunit.v3;
 
 public class TestWebApplicationFactoryFixture : WebApplicationFactory<Program>, ITestOutputHelperAccessor
 {
-    private readonly SqliteConnection _connection;
+    private readonly SqliteConnection? _connection;
+    private static bool UseRealServices =>
+        string.Equals(Environment.GetEnvironmentVariable("USE_REAL_SERVICES"), "true", StringComparison.OrdinalIgnoreCase);
 
     public TestWebApplicationFactoryFixture()
     {
         Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
 
-        // Keep a persistent connection for in-memory SQLite
-        _connection = new SqliteConnection("Data Source=:memory:");
-        _connection.Open();
+        if (!UseRealServices)
+        {
+            // Keep a persistent connection for in-memory SQLite
+            _connection = new SqliteConnection("Data Source=:memory:");
+            _connection.Open();
+        }
     }
 
     public ITestOutputHelper? OutputHelper { get; set; }
@@ -32,9 +37,12 @@ public class TestWebApplicationFactoryFixture : WebApplicationFactory<Program>, 
     {
         builder.ConfigureLogging(p => p.AddXUnit(this));
 
+        if (UseRealServices)
+            return;
+
         builder.ConfigureServices(services =>
             services.ReplaceDbProvider<AppDbContext>(options =>
-                options.UseSqlite(_connection)
+                options.UseSqlite(_connection!)
                        .AddTrellisInterceptors()));
     }
 
@@ -42,7 +50,7 @@ public class TestWebApplicationFactoryFixture : WebApplicationFactory<Program>, 
     {
         base.Dispose(disposing);
         if (disposing)
-            _connection.Dispose();
+            _connection?.Dispose();
     }
 }
 


### PR DESCRIPTION
Added upgrade instructions for Trellis NuGet packages, including syncing API reference files after version changes. Clarified documentation on committing reference updates. Modified `TestWebApplicationFactoryFixture` to support real services via `USE_REAL_SERVICES` env var, conditionally initializing the SQLite connection and updating service configuration. Ensured safe disposal of the connection.