### PR TITLE
docs: polish README with badges + Related Repositories + fix post-rename drift

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ This repository contains the **Trellis ASP.NET template** (`dotnet new`). There 
 ## Repository Structure
 
 ```
-TrellisAspTemplate/
+Trellis.AspTemplate/
 ├── templatepack.csproj            ← NuGet template pack project
 ├── version.json                   ← Nerdbank.GitVersioning
 ├── template/                      ← The actual template content (installed by `dotnet new`)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-# Trellis ASP.NET Service Template
+﻿# Trellis.AspTemplate
 
-Create a production-ready ASP.NET service with Trellis, layered architecture, testing, and observability already wired in.
+[![Build](https://github.com/xavierjohn/Trellis.AspTemplate/actions/workflows/build.yml/badge.svg)](https://github.com/xavierjohn/Trellis.AspTemplate/actions/workflows/build.yml)
+[![NuGet](https://img.shields.io/nuget/v/Trellis.AspTemplate.svg)](https://www.nuget.org/packages/Trellis.AspTemplate)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/Trellis.AspTemplate.svg)](https://www.nuget.org/packages/Trellis.AspTemplate)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![.NET](https://img.shields.io/badge/.NET-10.0-purple.svg)](https://dotnet.microsoft.com/download)
+[![C#](https://img.shields.io/badge/C%23-14.0-blue.svg)](https://docs.microsoft.com/en-us/dotnet/csharp/)
+[![GitHub Stars](https://img.shields.io/github/stars/xavierjohn/Trellis.AspTemplate?style=social)](https://github.com/xavierjohn/Trellis.AspTemplate/stargazers)
+
+> `dotnet new trellis-asp` template scaffolding a production-ready single-service ASP.NET application on the [Trellis framework](https://github.com/xavierjohn/Trellis) with Clean Architecture layout (API + Application + Domain + ACL), API versioning, EF Core, OpenAPI, and test infrastructure already wired in.
 
 ## Quick Start
 
@@ -57,10 +65,21 @@ Api -> Application -> Domain
 
 ## Documentation
 
-- Trellis docs: https://xavierjohn.github.io/Trellis/
-- Dev Container guide: https://github.com/xavierjohn/Trellis/blob/main/TrellisAspTemplate/template/.devcontainer/README.md
-- OpenTelemetry guide: https://github.com/xavierjohn/Trellis/blob/main/TrellisAspTemplate/template/DockerOpenTelemetry/README.md
+- Trellis docs: <https://xavierjohn.github.io/Trellis/>
+- Dev Container guide: [`template/.devcontainer/README.md`](https://github.com/xavierjohn/Trellis.AspTemplate/blob/main/template/.devcontainer/README.md)
+- OpenTelemetry guide: [`template/DockerOpenTelemetry/README.md`](https://github.com/xavierjohn/Trellis.AspTemplate/blob/main/template/DockerOpenTelemetry/README.md)
+
+## Related repositories
+
+- [`xavierjohn/Trellis`](https://github.com/xavierjohn/Trellis) — the framework: `Result<T>`, `Maybe<T>`, value objects, DDD primitives, ASP.NET / EF Core / Mediator integration.
+- [`xavierjohn/Trellis.Microservices`](https://github.com/xavierjohn/Trellis.Microservices) — microservice trust-boundary packages: YARP gateway integration + consumer-side actor provider for multi-tenant ABAC.
+- [`xavierjohn/Trellis.Microservices.Template`](https://github.com/xavierjohn/Trellis.Microservices.Template) — `dotnet new trellis-microservices` Project Tracker starter (multi-service topology with Aspire).
+- [`xavierjohn/Trellis.ServiceLevelIndicators`](https://github.com/xavierjohn/Trellis.ServiceLevelIndicators) — latency SLI metrics library for emitting operation-duration histograms via System.Diagnostics.Metrics + OpenTelemetry.
 
 ## Requirements
 
 - .NET 10 SDK
+
+## License
+
+[MIT](LICENSE).

--- a/templatepack.csproj
+++ b/templatepack.csproj
@@ -16,8 +16,8 @@
     <Description>A dotnet new template for creating ASP.NET services using the Trellis framework with Railway-Oriented Programming (ROP) and Domain-Driven Design (DDD). Includes solution structure, build system, test infrastructure, copilot instructions, and API reference.</Description>
     <Authors>Xavier John</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/xavierjohn/TrellisAspTemplate</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/xavierjohn/TrellisAspTemplate</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/xavierjohn/Trellis.AspTemplate</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/xavierjohn/Trellis.AspTemplate</RepositoryUrl>
     <PackageTags>dotnet-new;template;trellis;rop;ddd;aspnet;api;railway-oriented-programming;domain-driven-design</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
docs: polish README with badges + Related Repositories + fix post-rename drift

Brings the README into line with the cool xavierjohn/Trellis main-repo
README pattern + cleans up drift left over from the
TrellisAspTemplate -> Trellis.AspTemplate rename:

- Title bumped from "Trellis ASP.NET Service Template" to
  "Trellis.AspTemplate" so the page header matches the repo + the
  NuGet package id.
- Badge row at top: Build status, NuGet version + downloads for
  Trellis.AspTemplate, License (MIT), .NET 10.0, C# 14.0, GitHub stars.
- Tagline blockquote restating the one-line value proposition.
- Documentation links repointed at the canonical
  https://github.com/xavierjohn/Trellis.AspTemplate/blob/main/template/...
  paths (the previous links pointed at the long-removed
  xavierjohn/Trellis/blob/main/TrellisAspTemplate/... carve-out).
- Related repositories section added cross-linking the rest of the
  Trellis family (main framework, Microservices, Microservices.Template,
  ServiceLevelIndicators).

Drift cleanup outside the README:
- templatepack.csproj: PackageProjectUrl + RepositoryUrl repointed at
  Trellis.AspTemplate (were still TrellisAspTemplate; GitHub auto-redirects
  but the next NuGet publish will now embed the canonical URL).
- .github/copilot-instructions.md: repo-structure tree updated from
  TrellisAspTemplate/ to Trellis.AspTemplate/.
