### PR TITLE
chore: bump SLI to preview.24 + sync front-matter'd SLI docs

### DIFF
--- a/template/.github/trellis-api-sli-apiversioning.md
+++ b/template/.github/trellis-api-sli-apiversioning.md
@@ -1,3 +1,12 @@
+---
+package: Trellis.ServiceLevelIndicators.Asp.ApiVersioning
+namespaces: [Trellis.ServiceLevelIndicators]
+types: [ServiceLevelIndicatorServiceCollectionExtensions, ApiVersionEnrichment]
+version: v10
+last_verified: 2026-06-18
+audience: [llm]
+---
+
 # Trellis.ServiceLevelIndicators.Asp.ApiVersioning — API Reference
 
 **Package:** `Trellis.ServiceLevelIndicators.Asp.ApiVersioning`  

--- a/template/.github/trellis-api-sli-asp.md
+++ b/template/.github/trellis-api-sli-asp.md
@@ -1,3 +1,12 @@
+---
+package: Trellis.ServiceLevelIndicators.Asp
+namespaces: [Trellis.ServiceLevelIndicators]
+types: [IServiceLevelIndicatorBuilder, ServiceLevelIndicatorCoreServiceCollectionExtensions, ServiceLevelIndicatorServiceCollectionExtensions, ServiceLevelIndicatorApplicationBuilderExtensions, EndpointBuilderExtensions, ServiceLevelIndicatorAttribute, CustomerResourceIdAttribute, MeasureAttribute, CustomerResourceIdMetadata, MeasureMetadata, WebEnrichmentContext, IServiceLevelIndicatorFeature, HttpContextExtensions]
+version: v10
+last_verified: 2026-06-18
+audience: [llm]
+---
+
 # Trellis.ServiceLevelIndicators.Asp — API Reference
 
 **Package:** `Trellis.ServiceLevelIndicators.Asp`  

--- a/template/.github/trellis-api-sli.md
+++ b/template/.github/trellis-api-sli.md
@@ -1,3 +1,12 @@
+---
+package: Trellis.ServiceLevelIndicators
+namespaces: [Trellis.ServiceLevelIndicators]
+types: [ServiceLevelIndicator, ServiceLevelIndicatorOptions, MeasuredOperation, IEnrichmentContext, "IEnrichment<T>", ServiceLevelIndicatorMeterProviderBuilderExtensions]
+version: v10
+last_verified: 2026-06-18
+audience: [llm]
+---
+
 # Trellis.ServiceLevelIndicators — API Reference
 
 **Package:** `Trellis.ServiceLevelIndicators`  

--- a/template/Directory.Packages.props
+++ b/template/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <TrellisVersion>3.0.0-alpha.397</TrellisVersion>
+    <TrellisSliVersion>10.0.0-preview.24</TrellisSliVersion>
   </PropertyGroup>
   <!-- Runtime -->
   <ItemGroup>
@@ -36,9 +37,9 @@
     <PackageVersion Include="Trellis.Mediator.FluentValidation" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.Primitives" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.ServiceDefaults" Version="$(TrellisVersion)" />
-    <PackageVersion Include="Trellis.ServiceLevelIndicators" Version="10.0.0-preview.21" />
-    <PackageVersion Include="Trellis.ServiceLevelIndicators.Asp" Version="10.0.0-preview.21" />
-    <PackageVersion Include="Trellis.ServiceLevelIndicators.Asp.ApiVersioning" Version="10.0.0-preview.21" />
+    <PackageVersion Include="Trellis.ServiceLevelIndicators" Version="$(TrellisSliVersion)" />
+    <PackageVersion Include="Trellis.ServiceLevelIndicators.Asp" Version="$(TrellisSliVersion)" />
+    <PackageVersion Include="Trellis.ServiceLevelIndicators.Asp.ApiVersioning" Version="$(TrellisSliVersion)" />
     <PackageVersion Include="Trellis.StateMachine" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.Testing" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.Testing.AspNetCore" Version="$(TrellisVersion)" />


### PR DESCRIPTION
## Summary

Propagates the republished **Trellis.ServiceLevelIndicators preview.24** to the template.

## Changes
- **`template/Directory.Packages.props`** — bump `Trellis.ServiceLevelIndicators` (+ `.Asp` / `.Asp.ApiVersioning`) `preview.21` → `preview.24`, pinned via a new **`$(TrellisSliVersion)`** property (mirrors the existing `$(TrellisVersion)` pattern so the SLI trio bumps in lockstep).
- **`template/.github/trellis-api-sli*.md`** — re-synced from preview.24. These now carry the standard **YAML front matter** (`package` / `namespaces` / `types` / `version` / `last_verified` / `audience: [llm]`) added upstream in `xavierjohn/ServiceLevelIndicators` (#61/#62), bringing the SLI docs in line with the rest of the Trellis reference set. Content-only diff (+9/−0 per doc — just the front matter); kept at the template's LF/no-BOM convention.

## Verification
Release build **0 warnings / 0 errors**; **149/149 tests pass** against preview.24 (audit isolated — see note).

## ⚠️ Known CI failure (pre-existing, unrelated)
CI will red on **NU1903 / GHSA-2m69-gcr7-jv3q**: `SQLitePCLRaw.lib.e_sqlite3` 2.1.11, a transitive dependency of `Microsoft.EntityFrameworkCore.Sqlite` 10.0.9 (a newly-published advisory). This is **independent of this change** — it already affects `main` — and the only patched version (`3.50.3`) is a major re-versioning jump. It will be addressed in a **separate PR**.
